### PR TITLE
Allow building with GHC 9.10

### DIFF
--- a/sayable.cabal
+++ b/sayable.cabal
@@ -44,7 +44,7 @@ library
     hs-source-dirs:   .
     default-language: Haskell2010
     exposed-modules:  Text.Sayable
-    build-depends:    base >= 4.13 && < 4.20
+    build-depends:    base >= 4.13 && < 4.21
                     , containers
                     , exceptions
                     , bytestring
@@ -64,7 +64,7 @@ test-suite sayableTests
                     , hspec
                     , prettyprinter
                     , sayable
-                    , tasty >= 1.4 && < 1.5
+                    , tasty >= 1.4 && < 1.6
                     , tasty-ant-xml >= 1.1 && < 1.2
                     , tasty-hspec >= 1.2 && < 1.3
                     , template-haskell

--- a/sayable.cabal
+++ b/sayable.cabal
@@ -12,7 +12,7 @@ description:
    .
    * Brevity of syntax (using operators) designed to enhance conversion of
      arguments and readability of messages and conversion
-   
+
 license:            ISC
 license-file:       LICENSE
 author:             Kevin Quick


### PR DESCRIPTION
This bumps the upper version bounds for `base` and `tasty` to permit a build plan that is compatible with GHC 9.10.