### PR TITLE
Allow building with GHC 9.12

### DIFF
--- a/sayable.cabal
+++ b/sayable.cabal
@@ -51,7 +51,7 @@ library
     hs-source-dirs:   .
     default-language: Haskell2010
     exposed-modules:  Text.Sayable
-    build-depends:    base >= 4.13 && < 4.21
+    build-depends:    base >= 4.13 && < 4.22
                     , containers
                     , exceptions
                     , bytestring


### PR DESCRIPTION
This bumps the upper version bounds for `base` to permit a build plan that is compatible with GHC 9.12.